### PR TITLE
chore(ci): automate website deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+      - run: |
+          yarn install
+          yarn build
+          yarn deploy
+        env:
+          GIT_USER: ${{ GITHUB_ACTOR }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.idea/


### PR DESCRIPTION
Adds a Github action that automatically builds and deploys the openeew.com website whenever there is a push on `master` branch.

Closes #1 