### PR TITLE
Update custom.css

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
       id: "slack", // Any value that will identify this message.
       content:
         '♥ Join the community on <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/openeew/shared_invite/zt-cibhc0za-XKReMPobi2DsrPusORJZVQ">Slack</a> ♥',
-      backgroundColor: "#35e1ff", // Defaults to `#fff`.
+      backgroundColor: "#ffe93f", // Defaults to `#fff`.
       textColor: "#091E42", // Defaults to `#000`.
     },
     navbar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,13 +7,13 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #eb3a62;
-  --ifm-color-primary-dark: #ce4747;
-  --ifm-color-primary-darker: #a33838;
-  --ifm-color-primary-darkest: #7e2a2a;
-  --ifm-color-primary-light: #fd6c6c;
-  --ifm-color-primary-lighter: #fa7d7d;
-  --ifm-color-primary-lightest: #fd9494;
+  --ifm-color-primary: #ff3f6c;
+  --ifm-color-primary-dark: #ff1d52;
+  --ifm-color-primary-darker: #ff1d52;
+  --ifm-color-primary-darkest: #ef0038;
+  --ifm-color-primary-light: #ff7998;
+  --ifm-color-primary-lighter: #ff8aa5;
+  --ifm-color-primary-lightest: #ffbecd;
   --ifm-code-font-size: 95%;
 }
 


### PR DESCRIPTION
PR #13 updated the colors according to #12, but the new color do not match the Hue of the logo

Change Hue to match new logo better

For reference I chose the colors simply but inputting the original theme colors (before the change) and changing only the hue to match the logo (Hue 346)

Closes #12 